### PR TITLE
Added cf-hostname-uuid

### DIFF
--- a/common/src/main/bash/pipeline.sh
+++ b/common/src/main/bash/pipeline.sh
@@ -83,6 +83,9 @@ function deployAppWithName() {
     local manifestOption=$( if [[ "${useManifest}" == "false" ]] ; then echo "--no-manifest"; else echo "" ; fi )
     local lowerCaseAppName=$( echo "${appName}" | tr '[:upper:]' '[:lower:]' )
     local hostname="${lowerCaseAppName}"
+    if [[ ${CF_HOSTNAME_UUID} != "" ]]; then
+        hostname="${hostname}-${CF_HOSTNAME_UUID}"
+    fi
     if [[ ${env} != "prod" ]]; then
         hostname="${hostname}-${env}"
     fi

--- a/concourse/credentials-sample.yml
+++ b/concourse/credentials-sample.yml
@@ -15,6 +15,7 @@ stubrunner-artifact-id: github-analytics-stub-runner-boot
 stubrunner-version: 0.0.1.M1
 
 # credentials (defaults are for PCF Dev)
+cf-hostname-uuid:
 cf-test-api-url: https://api.local.pcfdev.io
 cf-stage-api-url: https://api.local.pcfdev.io
 cf-prod-api-url: https://api.local.pcfdev.io

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -107,6 +107,7 @@ jobs:
           - CF_TEST_ORG: {{cf-test-org}}
           - CF_TEST_SPACE: {{cf-test-space}}
           - CF_TEST_API_URL: {{cf-test-api-url}}
+          - CF_HOSTNAME_UUID: {{cf-hostname-uuid}}
 
   - name: test-smoke
     serial: true
@@ -243,6 +244,7 @@ jobs:
           - CF_STAGE_ORG: {{cf-stage-org}}
           - CF_STAGE_SPACE: {{cf-stage-space}}
           - CF_STAGE_API_URL: {{cf-stage-api-url}}
+          - CF_HOSTNAME_UUID: {{cf-hostname-uuid}}
 
   - name: stage-e2e
     serial: true
@@ -311,6 +313,7 @@ jobs:
           - CF_PROD_ORG: {{cf-prod-org}}
           - CF_PROD_SPACE: {{cf-prod-space}}
           - CF_PROD_API_URL: {{cf-prod-api-url}}
+          - CF_HOSTNAME_UUID: {{cf-hostname-uuid}}
       - put: repo
         params:
           repository: out


### PR DESCRIPTION
Adding a cf-hostname-uuid variable so that you can ensure your routes are unique. This is useful when deploying the demo to a shared environment such as PWS, where it is possible that someone has already run the demo and used the default routes.

For example, the demo creates routes using app name and environment, such as:
     github-eureka-test.local.pcfdev.io
     github-eureka-stage.local.pcfdev.io
     github-eureka.local.pcfdev.io

With cf-hostname-uuid=xyz, for example, the routes would instead be: 
     github-eureka-xyz-test.local.pcfdev.io
     github-eureka-xyz-stage.local.pcfdev.io
     github-eureka-xyz.local.pcfdev.io

