### PR TITLE
Fix remove-prod-tags.sh script

### DIFF
--- a/tools/remove-prod-tags.sh
+++ b/tools/remove-prod-tags.sh
@@ -21,10 +21,10 @@ mkdir -p "${__dir}/../target" && cd "${__dir}/../target"
 for REPO in ${REPOSITORIES}; do
 	if [[ ! -d "${REPO}" ]]; then
 		git clone "git@github.com:${GH_ORG}/${REPO}.git"
-	else
-		git fetch --prune --tags
 	fi
 	pushd "${REPO}"
-	git tag --list | grep '^prod/' | xargs -n1 git push --delete origin
+	while read -r TAG; do
+		git push --delete origin "${TAG}"
+	done < <( git ls-remote -q --tags origin | cut -f 2 | grep '^refs/tags/prod/' )
 	popd
 done


### PR DESCRIPTION
 - use ls-remote instead of local tags list,
 - do not use xargs as `--no-run-if-empty` is a GNU extension.