### PR TITLE
Provides a solution for caching build dependencies for maven gradle

### DIFF
--- a/concourse/credentials-sample.yml
+++ b/concourse/credentials-sample.yml
@@ -3,7 +3,6 @@ app-url: git@github.com:marcingrzejszczak/github-webhook.git
 app-branch: master
 tools-scripts-url: https://github.com/spring-cloud/spring-cloud-pipelines.git
 tools-branch: master
-maven-local-dir: m2/rootfs
 
 app-memory-limit: 256m
 java-buildpack-url: https://github.com/cloudfoundry/java-buildpack.git#v3.8.1

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -20,11 +20,6 @@ resources:
     uri: ((tools-scripts-url))
     branch: ((tools-branch))
 
-- name: m2
-  type: docker-image
-  source:
-    repository: springcloud/spring-pipeline-m2
-
 jobs:
 - name: generate-version
   public: true
@@ -48,7 +43,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -71,7 +65,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -89,7 +82,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -109,7 +101,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -128,7 +119,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -148,7 +138,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -167,7 +156,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -187,7 +175,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -206,7 +193,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:
@@ -231,7 +217,6 @@ jobs:
   - aggregate:
     - get: tools
     - get: repo
-    - get: m2
     - get: version
       resource: version
       passed:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -234,7 +234,6 @@ common-params: &common-params
   BUILD_OPTIONS: ((build-options))
   GIT_EMAIL: ((git-email))
   GIT_NAME: ((git-name))
-  M2_REPO: ((maven-local-dir))
   M2_SETTINGS_REPO_ID: ((m2-settings-repo-id))
   M2_SETTINGS_REPO_PASSWORD: ((m2-settings-repo-password))
   M2_SETTINGS_REPO_USERNAME: ((m2-settings-repo-username))

--- a/concourse/tasks/build-and-upload.yml
+++ b/concourse/tasks/build-and-upload.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/build-and-upload.yml
+++ b/concourse/tasks/build-and-upload.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/build-api-compatibility-check.yml
+++ b/concourse/tasks/build-api-compatibility-check.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/build-api-compatibility-check.yml
+++ b/concourse/tasks/build-api-compatibility-check.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/generate-settings.sh
+++ b/concourse/tasks/generate-settings.sh
@@ -3,16 +3,21 @@
 mkdir -p ${HOME}/.m2
 mkdir -p ${HOME}/.gradle
 
-ROOT_IN_M2_RESOURCE="${ROOT_FOLDER}/${M2_REPO}/root"
-export M2_HOME="${ROOT_IN_M2_RESOURCE}/.m2"
-export NEW_LOCAL_REPO="${M2_HOME}/repository/"
+# Maven wrapper script downloads the wrapper to $MAVEN_USER_HOME/wrapper
+export MAVEN_USER_HOME="${ROOT_FOLDER}/.m2"
+mkdir -p ${MAVEN_USER_HOME}
 
-cat > ${HOME}/.m2/settings.xml <<EOF
+export M2_HOME=${HOME}/.m2
+
+echo "Writing maven settings to [${M2_HOME}/settings.xml]"
+
+cat > ${M2_HOME}/settings.xml <<EOF
 
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository>${MAVEN_USER_HOME}/repository</localRepository>
       <servers>
         <server>
           <id>${M2_SETTINGS_REPO_ID}</id>
@@ -25,7 +30,7 @@ cat > ${HOME}/.m2/settings.xml <<EOF
 EOF
 echo "Settings xml written"
 
-export GRADLE_USER_HOME="${ROOT_IN_M2_RESOURCE}/.gradle"
+export GRADLE_USER_HOME="${ROOT_FOLDER}/.gradle"
 
 echo "Writing gradle.properties to [${GRADLE_USER_HOME}/gradle.properties]"
 
@@ -36,7 +41,3 @@ repoPassword=${M2_SETTINGS_REPO_PASSWORD}
 
 EOF
 echo "gradle.properties written"
-
-echo "Moving [${NEW_LOCAL_REPO}] [${HOME}] folder"
-mv ${NEW_LOCAL_REPO} ${HOME}/.m2/repository
-mv ${M2_HOME}/wrapper ${HOME}/.m2/wrapper

--- a/concourse/tasks/generate-settings.sh
+++ b/concourse/tasks/generate-settings.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 
-mkdir -p ${HOME}/.m2
-mkdir -p ${HOME}/.gradle
+M2_HOME="${HOME}/.m2"
+M2_CACHE="${ROOT_FOLDER}/.m2"
+GRADLE_HOME="${HOME}/.gradle"
+GRADLE_CACHE="${ROOT_FOLDER}/.gradle"
 
-# Maven wrapper script downloads the wrapper to $MAVEN_USER_HOME/wrapper
-export MAVEN_USER_HOME="${ROOT_FOLDER}/.m2"
-mkdir -p ${MAVEN_USER_HOME}
-
-export M2_HOME=${HOME}/.m2
+[[ -d $M2_CACHE && ! -d $M2_HOME ]] && ln -s $M2_CACHE $M2_HOME
+[[ -d $GRADLE_CACHE && ! -d $GRADLE_HOME ]] && ln -s $GRADLE_CACHE $GRADLE_HOME
 
 echo "Writing maven settings to [${M2_HOME}/settings.xml]"
 
-cat > ${M2_HOME}/settings.xml <<EOF
+cat > $M2_HOME/settings.xml <<EOF
 
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
-      <localRepository>${MAVEN_USER_HOME}/repository</localRepository>
       <servers>
         <server>
           <id>${M2_SETTINGS_REPO_ID}</id>
@@ -30,11 +28,9 @@ cat > ${M2_HOME}/settings.xml <<EOF
 EOF
 echo "Settings xml written"
 
-export GRADLE_USER_HOME="${ROOT_FOLDER}/.gradle"
+echo "Writing gradle.properties to [${GRADLE_HOME}/gradle.properties]"
 
-echo "Writing gradle.properties to [${GRADLE_USER_HOME}/gradle.properties]"
-
-cat > ${GRADLE_USER_HOME}/gradle.properties <<EOF
+cat > $GRADLE_HOME/gradle.properties <<EOF
 
 repoUsername=${M2_SETTINGS_REPO_USERNAME}
 repoPassword=${M2_SETTINGS_REPO_PASSWORD}

--- a/concourse/tasks/generate-settings.sh
+++ b/concourse/tasks/generate-settings.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 M2_HOME="${HOME}/.m2"
-M2_CACHE="${ROOT_FOLDER}/.m2"
+M2_CACHE="${ROOT_FOLDER}/maven"
 GRADLE_HOME="${HOME}/.gradle"
-GRADLE_CACHE="${ROOT_FOLDER}/.gradle"
+GRADLE_CACHE="${ROOT_FOLDER}/gradle"
 
 [[ -d $M2_CACHE && ! -d $M2_HOME ]] && ln -s $M2_CACHE $M2_HOME
 [[ -d $GRADLE_CACHE && ! -d $GRADLE_HOME ]] && ln -s $GRADLE_CACHE $GRADLE_HOME

--- a/concourse/tasks/prod-complete.yml
+++ b/concourse/tasks/prod-complete.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/prod-complete.yml
+++ b/concourse/tasks/prod-complete.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/prod-deploy.yml
+++ b/concourse/tasks/prod-deploy.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/prod-deploy.yml
+++ b/concourse/tasks/prod-deploy.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/stage-deploy.yml
+++ b/concourse/tasks/stage-deploy.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/stage-deploy.yml
+++ b/concourse/tasks/stage-deploy.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/stage-e2e.yml
+++ b/concourse/tasks/stage-e2e.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/stage-e2e.yml
+++ b/concourse/tasks/stage-e2e.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-deploy.yml
+++ b/concourse/tasks/test-deploy.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-deploy.yml
+++ b/concourse/tasks/test-deploy.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-rollback-deploy.yml
+++ b/concourse/tasks/test-rollback-deploy.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-rollback-deploy.yml
+++ b/concourse/tasks/test-rollback-deploy.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-rollback-smoke.yml
+++ b/concourse/tasks/test-rollback-smoke.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-rollback-smoke.yml
+++ b/concourse/tasks/test-rollback-smoke.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-smoke.yml
+++ b/concourse/tasks/test-smoke.yml
@@ -8,9 +8,11 @@ inputs:
   - name: tools
   - name: repo
   - name: version
-  - name: m2
 outputs:
   - name: out
+caches:
+  - path: .gradle/
+  - path: .m2/
 run:
   path: /bin/bash
   args:

--- a/concourse/tasks/test-smoke.yml
+++ b/concourse/tasks/test-smoke.yml
@@ -11,8 +11,8 @@ inputs:
 outputs:
   - name: out
 caches:
-  - path: .gradle/
-  - path: .m2/
+  - path: gradle
+  - path: maven
 run:
   path: /bin/bash
   args:


### PR DESCRIPTION
#68 Removed the m2 input from all the tasks and added caches for .m2 and .gradle directories.
Generate settings no longer copies contents from m2 resource and uses the Concourse cache feature instead, therefore, we could remove the m2 resource entirely along with the param to the m2 folder. This PR also caches the wrapper by setting the MAVEN_USER_HOME variable to the location of the m2 cache folder.