### PR TITLE
Adds follow-redirect to curl statement to support bintray.com

### DIFF
--- a/common/src/main/bash/projectType/pipeline-jvm.sh
+++ b/common/src/main/bash/projectType/pipeline-jvm.sh
@@ -35,7 +35,7 @@ function downloadAppBinary() {
 	mkdir -p "${OUTPUT_FOLDER}"
 	echo "Current folder is [$(pwd)]; Downloading binary to [${destination}]"
 	local success="false"
-	curl -u "${M2_SETTINGS_REPO_USERNAME}:${M2_SETTINGS_REPO_PASSWORD}" "${pathToJar}" -o "${destination}" --fail && success="true"
+	curl -u "${M2_SETTINGS_REPO_USERNAME}:${M2_SETTINGS_REPO_PASSWORD}" "${pathToJar}" -o "${destination}" --fail -L && success="true"
 	if [[ "${success}" == "true" ]]; then
 		echo "File downloaded successfully!"
 		return 0


### PR DESCRIPTION
Bintray responds to this request with a 302 to a cloudfront url.  This results in a 0 byte file being downloaded and when you go to start the app, it fails with following message: 

```
readat /tmp/build/4a5b55a7/repo/target/fortune-service-1.0.0.M1-20190228_125827-VERSION.jar: negative offset
```

By adding the -L to the curl command, curl will follow the redirect and correctly download the file.