### PR TITLE
URL Cleanup

### DIFF
--- a/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/mvnw
+++ b/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/mvnw.cmd
+++ b/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/pom.xml
+++ b/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>my-project</artifactId>

--- a/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/empty_project/mvnw
+++ b/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/empty_project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/buildSrc/src/test/resources/project_customizer/tools/cf-helper.sh
+++ b/buildSrc/src/test/resources/project_customizer/tools/cf-helper.sh
@@ -34,7 +34,7 @@ CF_DEFAULT_ORG="${CF_DEFAULT_ORG:-pcfdev-org}"
 export CF_DEFAULT_SPACE
 CF_DEFAULT_SPACE="${CF_DEFAULT_SPACE:-pcfdev-test}"
 export ARTIFACTORY_URL
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://repo.spring.io/libs-milestone}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://repo.spring.io/libs-milestone}"
 export EUREKA_MEMORY
 EUREKA_MEMORY="${EUREKA_MEMORY:-1024m}"
 

--- a/buildSrc/src/test/resources/project_customizer/tools/deploy-infra.sh
+++ b/buildSrc/src/test/resources/project_customizer/tools/deploy-infra.sh
@@ -7,7 +7,7 @@
 # Examples:
 #   $ ./tools/deploy-infra.sh
 #   $ ./tools/deploy-infra.sh ../repos/pivotal/
-#   $ ARTIFACTORY_URL="http://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
+#   $ ARTIFACTORY_URL="https://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
 #
 
 set -o errexit
@@ -23,7 +23,7 @@ if [[ -z "${POTENTIAL_DOCKER_HOST}" ]]; then
     POTENTIAL_DOCKER_HOST="localhost"
 fi
 
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
 ARTIFACTORY_ID="${ARTIFACTORY_ID:-artifactory-local}"
 
 function deploy_project {

--- a/common/src/test/bats/fixtures/maven/build_project/mvnw
+++ b/common/src/test/bats/fixtures/maven/build_project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/common/src/test/bats/fixtures/maven/build_project/mvnw.cmd
+++ b/common/src/test/bats/fixtures/maven/build_project/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/common/src/test/bats/fixtures/maven/build_project/pom.xml
+++ b/common/src/test/bats/fixtures/maven/build_project/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.example</groupId>
 	<artifactId>my-project</artifactId>

--- a/common/src/test/bats/fixtures/maven/empty_project/mvnw
+++ b/common/src/test/bats/fixtures/maven/empty_project/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/docs-sources/mvnw
+++ b/docs-sources/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/docs-sources/mvnw.cmd
+++ b/docs-sources/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/docs-sources/pom.xml
+++ b/docs-sources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.cloud</groupId>

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
 # Install cf-cli
 RUN apt-get -y install apt-transport-https && \
     wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
-    echo "deb http://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
+    echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
     apt-get -y update && \
     apt-get -y install cf-cli
 
@@ -75,7 +75,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install apt-tran
 # You can use Jenkins API to generate the list of plugins from a running
 # Jenkins instance:
 #
-#  $ JENKINS_URL="http://user:pass@localhost:8080"
+#  $ JENKINS_URL="https://user:pass@localhost:8080"
 #  $ curl -sSL "${JENKINS_URL}/pluginManager/api/json?depth=1" | \
 #    jq -r '.plugins[] | .shortName +":"+ .version' | sort > plugins.txt
 #

--- a/jenkins/build.gradle
+++ b/jenkins/build.gradle
@@ -14,7 +14,7 @@ sourceSets {
 repositories {
     jcenter()
     mavenCentral()
-    maven { url 'http://repo.jenkins-ci.org/releases/' }
+    maven { url 'https://repo.jenkins-ci.org/releases/' }
 }
 
 dependencies {

--- a/tools/cf-helper.sh
+++ b/tools/cf-helper.sh
@@ -34,7 +34,7 @@ CF_DEFAULT_ORG="${CF_DEFAULT_ORG:-pcfdev-org}"
 export CF_DEFAULT_SPACE
 CF_DEFAULT_SPACE="${CF_DEFAULT_SPACE:-pcfdev-test}"
 export ARTIFACTORY_URL
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://repo.spring.io/libs-milestone}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://repo.spring.io/libs-milestone}"
 export EUREKA_MEMORY
 EUREKA_MEMORY="${EUREKA_MEMORY:-1024m}"
 

--- a/tools/deploy-infra.sh
+++ b/tools/deploy-infra.sh
@@ -7,7 +7,7 @@
 # Examples:
 #   $ ./tools/deploy-infra.sh
 #   $ ./tools/deploy-infra.sh ../repos/pivotal/
-#   $ ARTIFACTORY_URL="http://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
+#   $ ARTIFACTORY_URL="https://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
 #
 
 set -o errexit
@@ -23,7 +23,7 @@ if [[ -z "${POTENTIAL_DOCKER_HOST}" ]]; then
     POTENTIAL_DOCKER_HOST="localhost"
 fi
 
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
 ARTIFACTORY_ID="${ARTIFACTORY_ID:-artifactory-local}"
 
 function deploy_project {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://rubygems-proxy.torquebox.org/releases/ (200) with 1 occurrences could not be migrated:  
   ([https](https://rubygems-proxy.torquebox.org/releases/) result SSLHandshakeException).
* http://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.catosplace.net/blog/2015/02/11/running-jenkins-in-docker-containers/) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://192.168.99.100:8081/artifactory/libs-release-local (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:8081/artifactory/libs-release-local ([https](https://192.168.99.100:8081/artifactory/libs-release-local) result ConnectTimeoutException).
* http://admin:password@ (UnknownHostException) with 2 occurrences migrated to:  
  https://admin:password@ ([https](https://admin:password@) result UnknownHostException).
* http://user:pass@localhost:8080 (UnknownHostException) with 1 occurrences migrated to:  
  https://user:pass@localhost:8080 ([https](https://user:pass@localhost:8080) result UnknownHostException).
* http://packages.cloudfoundry.org/debian (404) with 1 occurrences migrated to:  
  https://packages.cloudfoundry.org/debian ([https](https://packages.cloudfoundry.org/debian) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repo.jenkins-ci.org/releases/ with 1 occurrences migrated to:  
  https://repo.jenkins-ci.org/releases/ ([https](https://repo.jenkins-ci.org/releases/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 8 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://repo.spring.io/libs-milestone with 2 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8761 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences