### PR TITLE
URL Cleanup

### DIFF
--- a/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/pom.xml
+++ b/buildSrc/src/test/resources/project_customizer/common/src/test/bats/fixtures/maven/build_project/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.example</groupId>
     <artifactId>my-project</artifactId>

--- a/common/src/test/bats/fixtures/maven/build_project/pom.xml
+++ b/common/src/test/bats/fixtures/maven/build_project/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.example</groupId>
 	<artifactId>my-project</artifactId>

--- a/common/src/test/bats/fixtures/maven/multi_module/foo/bar/pom.xml
+++ b/common/src/test/bats/fixtures/maven/multi_module/foo/bar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>

--- a/common/src/test/bats/fixtures/maven/multi_module/foo/pom.xml
+++ b/common/src/test/bats/fixtures/maven/multi_module/foo/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.example</groupId>

--- a/common/src/test/bats/fixtures/maven/multi_module/pom.xml
+++ b/common/src/test/bats/fixtures/maven/multi_module/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.example</groupId>
 	<artifactId>my-project-parent</artifactId>

--- a/docs-sources/pom.xml
+++ b/docs-sources/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.cloud</groupId>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-build.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-build.xml
@@ -170,7 +170,7 @@
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-complete.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-complete.xml
@@ -107,7 +107,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-deploy.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-deploy.xml
@@ -123,7 +123,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-rollback.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-prod-env-rollback.xml
@@ -107,7 +107,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-stage-env-deploy.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-stage-env-deploy.xml
@@ -113,7 +113,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-stage-env-test.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-stage-env-test.xml
@@ -99,7 +99,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-deploy.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-deploy.xml
@@ -113,7 +113,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-rollback-deploy.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-rollback-deploy.xml
@@ -113,7 +113,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-rollback-test.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-rollback-test.xml
@@ -99,7 +99,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-test.xml
+++ b/jenkins/src/test/resources/default-pipeline/jobs/foo-pipeline-test-env-test.xml
@@ -99,7 +99,7 @@ set -o pipefail
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-build.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-build.xml
@@ -192,7 +192,7 @@ fi
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-prod-env-remove-tag.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-prod-env-remove-tag.xml
@@ -128,7 +128,7 @@ removeProdTag
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-prod-tag-repo.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-prod-tag-repo.xml
@@ -81,7 +81,7 @@ PAAS_TEST_SPACE_PREFIX=sc-pipelines-test</propertiesContent>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-stage-env-test.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-stage-env-test.xml
@@ -104,7 +104,7 @@ CF_SKIP_PREPARE_FOR_TESTS=true</propertiesContent>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-stage-prepare.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-stage-prepare.xml
@@ -118,7 +118,7 @@ waitForServicesToInitialize
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-env-rollback-test.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-env-rollback-test.xml
@@ -110,7 +110,7 @@ CF_SKIP_PREPARE_FOR_TESTS=true</propertiesContent>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-env-test.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-env-test.xml
@@ -105,7 +105,7 @@ CF_SKIP_PREPARE_FOR_TESTS=true</propertiesContent>
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>

--- a/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-prepare.xml
+++ b/jenkins/src/test/resources/spinnaker-jobs/jobs/spinnaker-foo-pipeline-test-prepare.xml
@@ -123,7 +123,7 @@ waitForServicesToInitialize
         <userRemoteConfigs>
             <hudson.plugins.git.UserRemoteConfig>
                 <name>origin</name>
-                <url>http://bar.com/baz/foo.git</url>
+                <url>https://bar.com/baz/foo.git</url>
                 <credentialsId>git</credentialsId>
             </hudson.plugins.git.UserRemoteConfig>
         </userRemoteConfigs>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://bar.com/baz/foo.git (301) with 18 occurrences migrated to:  
  https://bar.com/baz/foo.git ([https](https://bar.com/baz/foo.git) result IllegalArgumentException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 12 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 6 occurrences